### PR TITLE
Potential fix for code scanning alert no. 23: Clear-text logging of sensitive information

### DIFF
--- a/routes/auth.js
+++ b/routes/auth.js
@@ -31,7 +31,7 @@ module.exports = (authPool, convertBigIntToNumber) => {
             // Add debug logging
             console.log('=== LOGIN ATTEMPT ===');
             console.log('Username:', username);
-            console.log('Password length:', password ? password.length : 'undefined');
+            console.log('Password provided:', password ? 'Yes' : 'No');
             console.log('Remember Me:', rememberMe);
             
             const conn = await authPool.getConnection();


### PR DESCRIPTION
Potential fix for [https://github.com/lechibang-1512/Project-1/security/code-scanning/23](https://github.com/lechibang-1512/Project-1/security/code-scanning/23)

To fix the issue, we should remove the logging of the password length entirely. Debugging information should not include any data derived from sensitive information like passwords. Instead, we can log generic messages that do not expose sensitive details. For example, we can log that a password was provided or not, without revealing its length. This ensures that sensitive information is not exposed while still providing useful debugging information.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
